### PR TITLE
PR - Vertically centered `intro welcome text` properly

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,10 @@
             text-shadow:5px 5px 5px rgba(135,206,250,0.4);
 	}
 
+    .container .welcome-text {
+        padding-top: 10px;
+    }
+
     #delicon:hover {
         cursor: pointer;
     }
@@ -148,7 +152,7 @@
 
     <!--Section of Adding books-->
     <div class="container pt-4 mt-5 my-3">
-        <h1 class="text-center display-4 font-weight-bold">Welcome To Online Library</h1>
+        <h1 class="text-center display-4 font-weight-bold welcome-text">Welcome To Online Library</h1>
         <hr>
        <h1><font size="8px"><b>Add Your Book</b></font></h1>
         <form id="libraryForm">


### PR DESCRIPTION
Fix issue:
Closes #29 

The welcome text is now centered properly

**Screenshot**:
**Before:**
![image](https://user-images.githubusercontent.com/30120066/193459653-c3d626c7-39a8-4944-b543-184bc4816bef.png)

**After:**
![image](https://user-images.githubusercontent.com/30120066/193459623-e9317c81-105c-4dc3-b3d1-bfd15497a790.png)
