### PR TITLE
fixing typos in the FAQ section

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,11 +251,11 @@
             <p>
                 A simple library management project that is easy to use and helps learners understand the basic concept
                 of JS. In this project, the user has a provision to add book details like book name, author name, book
-                URL, ISBN, edition, publication date, the status of reading the book, and book genre through the web
+                URL, ISBN, edition, publication date, the status of reading the book and book genre through the web
                 page. In addition, the user has a provision to search for the available books in the library by the book
-                name, author name, or type. If book details are present in the LocalStorage, the search details are
+                name, author name or type. If the book details are present in the LocalStorage, the search details are
                 displayed on the web page. Users also have a provision to delete a specific book or all books. The user
-                can choose his favorites and edit any book details very quickly.
+                can choose his favorites and edit any book's details very quickly.
             </p>
         </div>
 
@@ -272,7 +272,7 @@
                 resources than a physical library can offer. This is because online libraries can acquire and make
                 available digital versions of resources from other libraries and publishers.<br>
                 3. Searchability: Online library systems often have search features that allow users to quickly and
-                easily find the resources they need. Users can search by title, author, subject, or keyword, making it
+                easily find the resources they need. Users can search by title, author, subject or keyword, making it
                 easier to locate relevant resources.<br>
                 4. 24/7 availability: Online library systems are available 24 hours a day, 7 days a week, allowing users
                 to access resources at any time, regardless of the library's physical operating hours.
@@ -281,7 +281,7 @@
 
         <div class="accordion">
             <div class="icon"></div>
-            <h5>Where does my books stored?</h5>
+            <h5>Where do my books get stored?</h5>
         </div>
         <div class="panel">
             <p>
@@ -326,7 +326,7 @@
         </div>
         <div class="panel">
             <p>
-                You can Store your books as much as you can!
+                You can store your books as much as you can!
             </p>
         </div>
 
@@ -336,7 +336,7 @@
         </div>
         <div class="panel">
             <p>
-                Not find your questions. Do mail your question at mail...
+                Cannot find your question? Feel free to write to us at our official email.
             </p>
         </div>
     </div>


### PR DESCRIPTION
I have fixed the typos in the FAQ section. These typos included incorrect usage of commas and a grammatical error in framing one of the questions. I have also rephrased the response to the last question.